### PR TITLE
V2 proposal

### DIFF
--- a/.nowignore
+++ b/.nowignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.circleci

--- a/next.config.js
+++ b/next.config.js
@@ -7,4 +7,5 @@ module.exports = {
 
     return config;
   },
+  target: 'serverless'
 };

--- a/now.json
+++ b/now.json
@@ -3,8 +3,32 @@
   "alias": "dougpalm",
   "name": "dougpalm",
   "builds": [
-    {"src": "package.json", "use": "@now/next"},
+    {"src": "package.json", "use": "@now/next@canary"},
     {"src": "static/**", "use": "@now/static"},
     {"src": "content/**", "use": "@now/static"}
+  ],
+  "routes": [
+    {
+      "src": "^/static/(.+)$",
+      "headers": { "Cache-Control": "s-maxage=31536000" },
+      "dest": "/static/$1"
+    },
+    {
+      "src": "^/content/(.+)$",
+      "headers": { "Cache-Control": "s-maxage=31536000" },
+      "dest": "/static/$1"
+    },
+    {
+      "src": "^/pages/(.*)$",
+      "dest": "/content/pages/$1"
+    },
+    {
+      "src": "^/blog/(.*)$",
+      "dest": "/content/blog/$1"
+    },
+    {
+      "src": "^/(.*)$",
+      "dest": "/$1"
+    }
   ]
 }

--- a/now.json
+++ b/now.json
@@ -3,7 +3,8 @@
   "alias": "dougpalm",
   "name": "dougpalm",
   "builds": [
-    {"src": "package.json", "use": "@now/next@canary"},
-    {"src": "static/**", "use": "@now/static"}
+    {"src": "package.json", "use": "@now/next"},
+    {"src": "static/**", "use": "@now/static"},
+    {"src": "content/**", "use": "@now/static"}
   ]
 }

--- a/now.json
+++ b/now.json
@@ -1,9 +1,9 @@
 {
-  "version": 1,
-  "type": "docker",
-  "features": {
-    "cloud": "v2"
-  },
+  "version": 2,
   "alias": "dougpalm",
-  "name": "dougpalm"
+  "name": "dougpalm",
+  "builds": [
+    {"src": "package.json", "use": "@now/next@canary"},
+    {"src": "static/**", "use": "@now/static"}
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "node server.js",
     "build": "next build",
+    "now-build": "next build",
     "start": "NODE_ENV=production node server.js"
   },
   "xo": {
@@ -29,7 +30,7 @@
     "he": "1.2.0",
     "lodash": "4.17.11",
     "moment": "^2.23.0",
-    "next": "7.0.2",
+    "next": "^8.0.0-canary.2",
     "path-match": "1.2.4",
     "prop-types": "15.6.2",
     "raw-loader": "1.0.0",


### PR DESCRIPTION
This is a proposal to make your app deploy successfully to v2. It is advised to change `now.json` from `@now/next@canary` to `@now/next` in a few days.